### PR TITLE
유저 팔로우 관련 기능 구현

### DIFF
--- a/project_pinned/apps/user/serializer.py
+++ b/project_pinned/apps/user/serializer.py
@@ -49,3 +49,11 @@ class RegisterSerializer(serializers.ModelSerializer):
 #         token["user_id"] = user.user_id
 
 #         return token
+
+
+class FollowUserSerializer(serializers.ModelSerializer):
+    
+    
+    class Meta:
+        model = User
+        fields = ("username", "profile_image")

--- a/project_pinned/apps/user/views.py
+++ b/project_pinned/apps/user/views.py
@@ -116,15 +116,15 @@ class UserFollow(APIView):
                 cur_user.following.add(target_user)
                 target_user.followers.add(cur_user)
                 return Response(
-                    {"is success": True, "detail": "user follow success"},
+                    {"is_success": True, "detail": "user follow success"},
                     status=status.HTTP_200_OK,
                 )
             return Response(
-                {"is success": False, "detail": "already followed user"},
+                {"is_success": False, "detail": "already followed user"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return Response(
-            {"is success": False, "detail": "You cannot follow yourself"},
+            {"is_success": False, "detail": "You cannot follow yourself"},
             status=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -147,15 +147,15 @@ class UserUnFollow(APIView):
                 cur_user.following.remove(target_user)
                 target_user.followers.remove(cur_user)
                 return Response(
-                    {"is success": True, "detail": "user unfollow success"},
+                    {"is_success": True, "detail": "user unfollow success"},
                     status=status.HTTP_200_OK,
                 )
             return Response(
-                {"is success": False, "detail": "already unfollowed user"},
+                {"is_success": False, "detail": "already unfollowed user"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return Response(
-            {"is success": False, "detail": "You cannot unfollow yourself"},
+            {"is_success": False, "detail": "You cannot unfollow yourself"},
             status=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/project_pinned/apps/user/views.py
+++ b/project_pinned/apps/user/views.py
@@ -116,15 +116,15 @@ class UserFollow(APIView):
                 cur_user.following.add(target_user)
                 target_user.followers.add(cur_user)
                 return Response(
-                    {"is success": "true", "detail": "user follow success"},
+                    {"is success": True, "detail": "user follow success"},
                     status=status.HTTP_200_OK,
                 )
             return Response(
-                {"is success": "false", "detail": "already followed user"},
+                {"is success": False, "detail": "already followed user"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return Response(
-            {"is success": "false", "detail": "You cannot follow yourself"},
+            {"is success": False, "detail": "You cannot follow yourself"},
             status=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -147,15 +147,15 @@ class UserUnFollow(APIView):
                 cur_user.following.remove(target_user)
                 target_user.followers.remove(cur_user)
                 return Response(
-                    {"is success": "true", "detail": "user unfollow success"},
+                    {"is success": True, "detail": "user unfollow success"},
                     status=status.HTTP_200_OK,
                 )
             return Response(
-                {"is success": "false", "detail": "already unfollowed user"},
+                {"is success": False, "detail": "already unfollowed user"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return Response(
-            {"is success": "false", "detail": "You cannot unfollow yourself"},
+            {"is success": False, "detail": "You cannot unfollow yourself"},
             status=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/project_pinned/apps/user/views.py
+++ b/project_pinned/apps/user/views.py
@@ -7,9 +7,11 @@ from rest_framework import permissions, status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework.permissions import IsAuthenticated
+from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from . import authentication
-from .serializer import RegisterSerializer
+from .serializer import FollowUserSerializer, RegisterSerializer
 
 User = get_user_model()
 
@@ -48,6 +50,7 @@ class UserRegister(APIView):
         "email": string,
         "password": string,
     """
+
     permission_classes = (permissions.AllowAny,)
 
     def post(self, request):
@@ -57,13 +60,19 @@ class UserRegister(APIView):
             try:
                 self.perform_user_create(serializer)
 
-                return Response(data={"is_success": True, "detail": "register success"}, status=status.HTTP_201_CREATED)
+                return Response(
+                    data={"is_success": True, "detail": "register success"},
+                    status=status.HTTP_201_CREATED,
+                )
 
             except IntegrityError:
-                user = User.objects.get(email=request.data.get('email'))
+                user = User.objects.get(email=request.data.get("email"))
 
                 if user:
-                    return Response(data={"detail": "User exist."}, status=status.HTTP_400_BAD_REQUEST)
+                    return Response(
+                        data={"detail": "User exist."},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
 
     def perform_user_create(self, serializer):
         if serializer.is_valid(raise_exception=True):
@@ -90,28 +99,84 @@ class UserProfile(APIView):
 
 
 class UserFollow(APIView):
-    authentication_classes = (authentication.JWTAuthentication,)
+    """
+    request:
+        "user_id": string,
+    """
+    
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
 
-    def post(self, request):
-        pass
+    def post(self, request, user_id):
+        target_user_id = request.data.get("user_id")
+        if user_id != target_user_id:
+            cur_user = User.objects.get(user_id=user_id)
+            target_user = User.objects.get(user_id=target_user_id)
+            if not cur_user.followers.filter(user_id=target_user_id).exists():
+                cur_user.followers.add(target_user)
+                target_user.following.add(cur_user)
+                return Response(
+                    {"is success": "true", "detail": "user follow success"},
+                    status=status.HTTP_200_OK,
+                )
+            return Response(
+                {"is success": "false", "detail": "already followed user"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response(
+            {"is success": "false", "detail": "You cannot follow yourself"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
 
 
 class UserUnFollow(APIView):
-    authentication_classes = (authentication.JWTAuthentication,)
+    """
+    request:
+        "user_id": string,
+    """
 
-    def post(self, request):
-        pass
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, user_id):
+        target_user_id = request.data.get("user_id")
+        if user_id != target_user_id:
+            cur_user = User.objects.get(user_id=user_id)
+            target_user = User.objects.get(user_id=target_user_id)
+            if cur_user.followers.filter(user_id=target_user_id).exists():
+                cur_user.followers.remove(target_user)
+                target_user.following.remove(cur_user)
+                return Response(
+                    {"is success": "true", "detail": "user unfollow success"},
+                    status=status.HTTP_200_OK,
+                )
+            return Response(
+                {"is success": "false", "detail": "already unfollowed user"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response(
+            {"is success": "false", "detail": "You cannot unfollow yourself"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
 
 
 class UserFollowers(APIView):
-    authentication_classes = (authentication.JWTAuthentication,)
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
 
-    def get(self, request):
-        pass
+    def get(self, request, user_id):
+        cur_user = User.objects.get(user_id=user_id)
+        followers_list = cur_user.followers.all()
+        serializer = FollowUserSerializer(followers_list, many=True)
+        return Response({"followers_list": serializer.data}, status=status.HTTP_200_OK)
 
 
 class UserFollowings(APIView):
-    authentication_classes = (authentication.JWTAuthentication,)
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
 
-    def get(self, request):
-        pass
+    def get(self, request, user_id):
+        cur_user = User.objects.get(user_id=user_id)
+        followings_list = cur_user.following.all()
+        serializer = FollowUserSerializer(followings_list, many=True)
+        return Response({"followings_list": serializer.data}, status=status.HTTP_200_OK)

--- a/project_pinned/apps/user/views.py
+++ b/project_pinned/apps/user/views.py
@@ -112,9 +112,9 @@ class UserFollow(APIView):
         if user_id != target_user_id:
             cur_user = User.objects.get(user_id=user_id)
             target_user = User.objects.get(user_id=target_user_id)
-            if not cur_user.followers.filter(user_id=target_user_id).exists():
-                cur_user.followers.add(target_user)
-                target_user.following.add(cur_user)
+            if not cur_user.following.filter(user_id=target_user_id).exists():
+                cur_user.following.add(target_user)
+                target_user.followers.add(cur_user)
                 return Response(
                     {"is success": "true", "detail": "user follow success"},
                     status=status.HTTP_200_OK,
@@ -143,9 +143,9 @@ class UserUnFollow(APIView):
         if user_id != target_user_id:
             cur_user = User.objects.get(user_id=user_id)
             target_user = User.objects.get(user_id=target_user_id)
-            if cur_user.followers.filter(user_id=target_user_id).exists():
-                cur_user.followers.remove(target_user)
-                target_user.following.remove(cur_user)
+            if cur_user.following.filter(user_id=target_user_id).exists():
+                cur_user.following.remove(target_user)
+                target_user.followers.remove(cur_user)
                 return Response(
                     {"is success": "true", "detail": "user unfollow success"},
                     status=status.HTTP_200_OK,


### PR DESCRIPTION
## Description (요약)

- 유저 팔로우 기능 구현
- 유저 언팔로우 기능 구현
- 특정 유저의 팔로워 목록을 확인하는 기능 구현
- 특정 유저의 팔로잉 목록을 확인하는 기능 구현

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [X] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)
Postman
버전 10.15.0

## Major Changes (주요 변경사항)

- 팔로워와 팔로잉 목록 반환을 위해 user app의 serializer.py에 FollowUserSerializer class 구현
```
class FollowUserSerializer(serializers.ModelSerializer):
    
    
    class Meta:
        model = User
        fields = ("username", "profile_image")
```
- 팔로우와 언팔로우 기능의 예외 상황에 응답 추가
- 특정 유저가 이미 팔로우된 유저를 팔로우하려고 할 시
```
 > 400 BAD REQUEST
{
    "is_success": False,
    "detail": already followed user,
}
```
- 특정 유저가 자기 자신을 팔로우하려고 할 시
```
 > 400 BAD REQUEST
{
    "is_success": True,
    "detail": You cannot follow yourself,
}
```
- 특정 유저가 팔로우되지 않은 유저를 언팔로우하려고 할 시
```
 > 400 BAD REQUEST
{
    "is_success": False,
    "detail": already unfollowed user,
}
```
- 특정 유저가 자기 자신을 언팔로우하려고 할 시
```
 > 400 BAD REQUEST
{
    "is_success": False,
    "detail": You cannot unfollow yourself,
}
```


## Screenshots (optional)


## Etc (비고)
- 팔로우 시 팔로잉 목록에 추가되지 않고 팔로워 목록에 추가되던 버그를 고침
- 팔로우와 언팔로우 기능에서 응답의 is_success 속성의 문자열로 반환하던 것을 Boolean으로 반환하도록 고침
- is_success 속성을 is success 로 반환하던 것을 고침