### PR TITLE
팔로우 로직 수정, 토큰 기능 구현

### DIFF
--- a/project_pinned/apps/user/urls.py
+++ b/project_pinned/apps/user/urls.py
@@ -1,7 +1,11 @@
 from django.urls import path, include
 from dj_rest_auth.views import LoginView, LogoutView
 
-from rest_framework_simplejwt.views import TokenVerifyView, TokenRefreshView, TokenBlacklistView
+from rest_framework_simplejwt.views import (
+    TokenVerifyView,
+    TokenRefreshView,
+    TokenBlacklistView,
+)
 
 from . import views
 
@@ -9,7 +13,7 @@ from . import views
 token_patterns = [
     path("verify/", TokenVerifyView.as_view(), name="jwt-verify"),
     path("refresh/", TokenRefreshView.as_view(), name="jwt-refresh"),
-    path("blacklist/", TokenBlacklistView.as_view(), name='jwt-blacklist'),
+    path("blacklist/", TokenBlacklistView.as_view(), name="jwt-blacklist"),
 ]
 
 urlpatterns = [
@@ -22,7 +26,7 @@ urlpatterns = [
     path("register/", views.UserRegister.as_view(), name="user-register"),
 
     # For individual user's information
-    path("<user_id>/", views.UserDelete.as_view(), name="user-delete"),
+    path("<user_id>/withdrawal", views.UserDelete.as_view(), name="user-delete"),
     path("<user_id>/profile/", views.UserProfile.as_view(), name="user-profile"),
     path("<user_id>/follow/", views.UserFollow.as_view(), name="user-follow"),
     path("<user_id>/unfollow/", views.UserUnFollow.as_view(), name="user-unfollow"),


### PR DESCRIPTION
…wal, 로직에 주석 추가

## Description (요약)
- 토큰 기능 simplejwt 라이브러리 기능 채택.
- 팔로우, 언팔로우 기능 수정 -> url에 명시되어 있는 user_id가 가리키는 유저를 팔로우/언팔로우 하도록 수정.

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [X] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)
Postman for Mac

Version 10.8.7

UI Version 10.8.7-ui-230125-1159

Desktop Platform Version 10.8.0

Architecture arm64

OS Platform OS X 22.3.0

## Major Changes (주요 변경사항)
 - 토큰 기능 Django rest_framework - simple_jwt 라이브러리에서 제공하는 기능 채택.

token refresh, verify 기능을 simple jwt 제공 기능을 사용.
라이브러리의 뷰 로직에 맞춰 API 문서 또한 수정 완료.

 - 유저 팔로우, 언팔로우 기능 수정

이전 로직은 API url에 명시되어 있는 user_id가 자신을 가리키고, request body에 명시되어 있는 user_id가 팔로우 혹은 언팔로우할 유저를 가리켰다면,

변경한 로직은 request body 파라미터를 모두 없애고 API url에 명시되어 있는 user_id가 팔로우 혹은 언팔로우할 유저를 명시하도록 변경.

로직을 이렇게 변경한 이유는 이미 JWTAuthentication, IsAuthenticated class들을 통해 이미 유저 자기 자신의 정보가 세션 파라미터에 포함되어 있으며, URL에 자기 자신의 user_id가 중복 명시되는 현상이 존재.

SNS 구조상 로그인한 유저가 팔로우 혹은 언팔로우할 유저를 직접 찾아서 팔로우 또는 언팔로우를 수행하기에 유즈케이스 흐름상 이렇게 로직을 변경하는 것이 자연스럽다.

따라서 결론적으로 api/v1/user/<user_id>/follow 및 api/v1/user/<user_id>/unfollow API 엔드포인트에서 user_id가 가리키는 유저는 팔로우 혹은 언팔로우의 '대상'이 되는 유저이다. **로그인 되어 있는 유저 자기 자신이 아니다**

 - user/views.py 주석 수정

UserRegister 클래스의 주석 중 "user_name": string 이라고 표기되던 것을 "username": string 으로 현재 user model 컬럼 이름에 맞게 표기 및 표시되도록 수정.

## Screenshots (optional)
<img width="477" alt="스크린샷 2023-06-27 오후 12 23 49" src="https://github.com/bnbong/Project-Pinned/assets/55042923/7a27ba10-37ba-4d54-a00b-b6507709d780">

첫 번째 유저 회원가입. username = test1, email = test1@testmail.com

<img width="478" alt="스크린샷 2023-06-27 오후 12 23 55" src="https://github.com/bnbong/Project-Pinned/assets/55042923/3fbdb19b-10a6-4962-b700-b24d9f864d6c">

첫 번째 유저 회원가입 성공.

<img width="478" alt="스크린샷 2023-06-27 오후 12 24 24" src="https://github.com/bnbong/Project-Pinned/assets/55042923/cbb8ef09-0d3e-4799-8b33-9315590b990e">

두 번째 유저 회원가입. username = test2, email = test2@testmail.com

<img width="479" alt="스크린샷 2023-06-27 오후 12 24 27" src="https://github.com/bnbong/Project-Pinned/assets/55042923/007364db-38cd-4532-a910-6413f5d00254">

두 번째 유저 회원가입 성공.

<img width="478" alt="스크린샷 2023-06-27 오후 12 24 39" src="https://github.com/bnbong/Project-Pinned/assets/55042923/933d8922-6897-4fa9-a0ec-335bb8c3cadd">

첫 번째 유저로 로그인 시도.

<img width="479" alt="스크린샷 2023-06-27 오후 12 24 44" src="https://github.com/bnbong/Project-Pinned/assets/55042923/acbe2a46-74e8-45ea-84c9-82bb8addc36e">

첫 번째 유저 로그인 성공. 로그인 성공 시 access_token, refresh_token이 함께 발급됨.
로그인 후 뜨는 유저 정보는 추후 커밋을 통해 수정할 예정.

![스크린샷 2023-06-27 오후 12 25 21](https://github.com/bnbong/Project-Pinned/assets/55042923/86cae827-d360-47f9-97ae-7892110bfe2f)

DB에 두 유저의 정보가 저장된 모습.

<img width="1392" alt="스크린샷 2023-06-27 오후 12 32 04" src="https://github.com/bnbong/Project-Pinned/assets/55042923/a480265c-7fe0-4bbc-b5ad-476b47bb7d7a">

user1으로 로그인한 상태에서 user2로 팔로우를 건 모습.
Header parameter로 넘겨진 Authroization Bearer <token>의 <token>부분에는 user1의 access_token이 담겨있다.

![스크린샷 2023-06-27 오후 12 33 06](https://github.com/bnbong/Project-Pinned/assets/55042923/71c370e2-3b0e-4dd8-882f-1bb63c01fd4d)

DB에 팔로우한 상태가 저장된 모습.

<img width="1392" alt="스크린샷 2023-06-27 오후 12 32 15" src="https://github.com/bnbong/Project-Pinned/assets/55042923/09cdd24c-1054-4827-8cb2-681de69457e3">

이미 팔로우한 유저를 다시 팔로우하려고 했을 때의 모습.

<img width="1392" alt="스크린샷 2023-06-27 오후 12 32 22" src="https://github.com/bnbong/Project-Pinned/assets/55042923/01002280-c884-4683-a79f-f7bd06b7fa0a">

자기 자신을 팔로우하려고 했을 때의 모습.

<img width="1392" alt="스크린샷 2023-06-27 오후 12 32 35" src="https://github.com/bnbong/Project-Pinned/assets/55042923/c941710b-84d8-4c22-8702-4845ce77bcce">

팔로우했던 유저를 언팔로우했을 때의 모습.

![스크린샷 2023-06-27 오후 12 32 58](https://github.com/bnbong/Project-Pinned/assets/55042923/9c7d0de4-077a-46b1-a092-6541a6743cf2)

DB에 팔로우 했던 상태가 취소되어 삭제된 것이 반영된 모습.

<img width="1392" alt="스크린샷 2023-06-27 오후 12 32 38" src="https://github.com/bnbong/Project-Pinned/assets/55042923/55e6b170-afb5-46bc-9754-8ccbdc7e2200">

이미 언팔로우한 유저를 다시 언팔로우했을 때의 모습.


## Etc (비고)
다음 커밋 혹은 PR까지 UserProfile 기능 구현이 완료되면 유저 관련 기능 전반에 대한 개발 완료.

TODO: 
1. Login 성공 시 뜨는 유저 정보를 수정해야함. -> UserLoginResponseSerializer 정의 예정.
 


