### PR TITLE
댓글 관련 기능 구현

### DIFF
--- a/project_pinned/apps/post/serializers.py
+++ b/project_pinned/apps/post/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import Post, Image, Landmark
+from .models import Post, Image, Landmark, Comment
 
 
 class ImageSerializer(serializers.ModelSerializer):
@@ -94,4 +94,17 @@ class PostSerializer(serializers.ModelSerializer):
             "created_at",
             "likes",
             "comments",
+        )
+
+
+class CommentSerializer(serializers.ModelSerializer):
+    username = serializers.CharField(source="user.username", required=False)
+    comment_content = serializers.CharField(source="content")
+
+    class Meta:
+        model = Comment
+        fields = (
+            "username",
+            "comment_content",
+            "created_at",
         )

--- a/project_pinned/apps/post/serializers.py
+++ b/project_pinned/apps/post/serializers.py
@@ -98,12 +98,14 @@ class PostSerializer(serializers.ModelSerializer):
 
 
 class CommentSerializer(serializers.ModelSerializer):
+    comment_id = serializers.IntegerField(source="id", required=False)
     username = serializers.CharField(source="user.username", required=False)
     comment_content = serializers.CharField(source="content")
 
     class Meta:
         model = Comment
         fields = (
+            "comment_id",
             "username",
             "comment_content",
             "created_at",

--- a/project_pinned/apps/post/tests.py
+++ b/project_pinned/apps/post/tests.py
@@ -92,7 +92,7 @@ class PostTests(TestCase):
         pass
 
     def test_create_comment(self):
-        url = reverse("comment-create")
+        url = reverse("comment-create", kwargs={"post_id": self.post.id})
         data = {
             "comment_content": "Test Comment",
         }
@@ -136,7 +136,7 @@ class PostTests(TestCase):
         self.assertFalse(Comment.objects.filter(id=self.comment.id).exists())
 
     def test_get_comments(self):
-        url = reverse("comment-view", kwargs={"post_id": self.post.id})
+        url = reverse("comment-create", kwargs={"post_id": self.post.id})
         self.client.force_authenticate(user=self.user)
         response = self.client.get(url)
 

--- a/project_pinned/apps/post/urls.py
+++ b/project_pinned/apps/post/urls.py
@@ -8,9 +8,7 @@ urlpatterns = [
     # Post CRUD & User's Posts and User's Feed
     path("", views.PostCreate.as_view(), name="post-create"),
     path("feed/", views.PostFeed.as_view(), name="post-feed"),
-
-    path("<user_id>/", views.PostsByUser.as_view(), name="posts-by-user"),
-
+    path("posts/<user_id>/", views.PostsByUser.as_view(), name="posts-by-user"),
     path("<post_id>/", views.PostView.as_view(), name="post-view"),
     # Comment CRUD
     path("<post_id>/comments/", views.CommentCreate.as_view(), name="comment-create"),

--- a/project_pinned/apps/post/views.py
+++ b/project_pinned/apps/post/views.py
@@ -11,7 +11,7 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 from apps.user.models import User
 
 from .models import Post
-from .serializers import PostSerializer, PostCreateSerializer
+from .serializers import PostSerializer, PostCreateSerializer, CommentSerializer
 
 
 class PostViewTest(View):
@@ -191,7 +191,21 @@ class CommentCreate(APIView):
         pass
 
     def post(self, request, post_id):
-        pass
+        serializer = CommentSerializer(data=request.data)
+        if serializer.is_valid():
+            try:
+                post = Post.objects.get(id=post_id)
+            except Post.DoesNotExist:
+                return Response(
+                    {"detail": "Post not found"}, status=status.HTTP_400_BAD_REQUEST
+                )
+
+            comment = serializer.save(user=request.user, post=post)
+            return Response(
+                {"is_success": True, "detail": "comment create success"},
+                status=status.HTTP_201_CREATED,
+            )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def get_permissions(self):
         if self.request.method == "GET":

--- a/project_pinned/apps/post/views.py
+++ b/project_pinned/apps/post/views.py
@@ -10,7 +10,7 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from apps.user.models import User
 
-from .models import Post
+from .models import Post, Comment
 from .serializers import PostSerializer, PostCreateSerializer, CommentSerializer
 
 
@@ -188,7 +188,16 @@ class CommentCreate(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, post_id):
-        pass
+        try:
+            post = Post.objects.get(id=post_id)
+        except Post.DoesNotExist:
+            return Response(
+                {"detail": "Post not found"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        comments = Comment.objects.filter(post=post)
+        serializer = CommentSerializer(comments, many=True)
+        return Response({"comments": serializer.data}, status=status.HTTP_200_OK)
 
     def post(self, request, post_id):
         serializer = CommentSerializer(data=request.data)
@@ -222,13 +231,58 @@ class CommentView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, post_id, comment_id):
-        pass
+        try:
+            comment = Comment.objects.get(id=comment_id, post_id=post_id)
+        except Comment.DoesNotExist:
+            return Response(
+                {"detail": "Comment not found"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        serializer = CommentSerializer(comment)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     def put(self, request, post_id, comment_id):
-        pass
+        try:
+            comment = Comment.objects.get(id=comment_id, post_id=post_id)
+        except Comment.DoesNotExist:
+            return Response(
+                {"detail": "Comment not found"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if comment.user.user_id != request.user.user_id:
+            return Response(
+                {"is_success": False, "detail": "Permission denied."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = CommentSerializer(comment, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(
+                {"is_success": True, "detail": "comment edit success"},
+                status=status.HTTP_200_OK,
+            )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, post_id, comment_id):
-        pass
+        try:
+            comment = Comment.objects.get(id=comment_id, post_id=post_id)
+        except Comment.DoesNotExist:
+            return Response(
+                {"detail": "Comment not found"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if comment.user.user_id != request.user.user_id:
+            return Response(
+                {"is_success": False, "detail": "Permission denied."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        comment.delete()
+        return Response(
+            {"is_success": True, "detail": "comment delete success"},
+            status=status.HTTP_204_NO_CONTENT,
+        )
 
     def get_permissions(self):
         if self.request.method == "GET":


### PR DESCRIPTION
## Description (요약)

- 댓글 작성, 읽기, 수정, 삭제 기능 구현
- 특정 유저가 작성한 게시물들을 보는 기능의 라우팅 주소 변경
- 댓글을 읽어오는 API의 Response에 comment_id 추가 

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [X] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)
Postman (v10.15)

## Major Changes (주요 변경사항)
### 구현한 API
- [POST] api/v1/post/{post_id}/comments
- [GET] api/v1/post/{post_id}/comments/{comment_id}
- [GET] api/v1/post/{post_id}/comments
- [PUT] api/v1/post/{post_id}/comments/{comment_id}
- [DELETE] api/v1/post/{post_id}/comments/{comment_id}

### 라우팅 주소 변경

- 특정 유저의 게시물들을 가져오는 API인 [GET] api/v1/post/{user_id} 과 게시물 읽기, 수정, 삭제 API인 [GET, PUT, DELTE] api/v1/post/{post_id}가 충돌을 일으킴
- 특정 유저의 게시물들을 가져오는 API의 라우팅 주소 [GET] api/v1/post/{user_id}를 [GET] api/v1/post/posts/{user_id} 로 변경

### 댓글을 읽어오는 API의 Response에 comment_id 추가

- 프론트엔드 측에서 comment_id가 필요한 API를 호출 가능하게 하기 위해 comment_id를 응답에 추가하였음

## Screenshots (optional)


## Etc (비고)
유저 피드 게시물들을 불러오는 기능의 테스트 코드 작성 필요